### PR TITLE
Added typecasting filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 Making twig do things it really shouldn&#39;t. Twig is not intended to be a general purpose programming language, and there are some things that really don't belong in the language. This plugin adds a few of those things anyway.
 
-- {% break %}, {% continue %}, and {% return %} tags
+- `{% break %}`, `{% continue %}`, and `{% return %}` tags
 - `is numeric` test
 - `json_decode` filter
 - `array_splice` filter
+- `string` and `s` filters
+- `float` and `f` filters
+- `int` and `i` filters
+- `bool` and `b` filters
 
 ## Installation
 
@@ -55,6 +59,7 @@ A macro with a `{% return %}` tag will return whatever the return value is (whic
 
 ### Tests
 - **Numeric**
+
   Test whether given value is numeric (behaviour like PHP 7 `is_numeric`). (Note that as of PHP 7, hexadecimal strings are not considered numeric)
 
 #### Examples
@@ -74,9 +79,27 @@ A macro with a `{% return %}` tag will return whatever the return value is (whic
 
 ### Filters
 - **json_decode**
+
   Decode json string, returning php associative arrays. Uses the PHP [json_decode](http://php.net/manual/en/function.json-decode.php) function
 
 - **array_splice**
+
   Remove a portion of an array and replace it with something else. Uses the PHP [array_splice](http://php.net/manual/en/function.array-splice.php) function. Note that unlike the php function, this filter returns the modified array rather than the extracted elements. The original array is unchanged. Since the implementation requires copying the array, this will be less efficient than the raw php function. The **array_splice** filter is passed an `offset`, an optional `length`, and an optional `replacement`.
+
+- **string** or **s**
+
+  Typecast variable as a string.
+
+- **float** or **f**
+
+  Typecast variable as a float.
+
+- **int** or **i**
+
+  Typecast variable as an integer.
+
+- **bool** or **b**
+
+  Typecast variable as a boolean.
 
 Brought to you by [Marion Newlevant](http://marion.newlevant.com)

--- a/src/twigextensions/TwigPerversionTwigExtension.php
+++ b/src/twigextensions/TwigPerversionTwigExtension.php
@@ -57,7 +57,7 @@ class TwigPerversionTwigExtension extends \Twig_Extension
 			new \Twig_Filter('json_decode', function($str) {
 				return json_decode($str, true); // return assoc arrays (more twig-like)
 			}),
-			
+
 			new \Twig_Filter('array_splice', function(array $input, int $offset, int $length = null, $replacement = null) {
 				if (is_null($length))
 				{
@@ -71,7 +71,59 @@ class TwigPerversionTwigExtension extends \Twig_Extension
 				return $input;
 			}),
 
+			new \Twig_SimpleFilter('string', [$this, 'string']),
+			new \Twig_SimpleFilter('float',  [$this, 'float']),
+			new \Twig_SimpleFilter('int',    [$this, 'int']),
+			new \Twig_SimpleFilter('bool',   [$this, 'bool']),
+			new \Twig_SimpleFilter('s', [$this, 'string']),
+			new \Twig_SimpleFilter('f', [$this, 'float']),
+			new \Twig_SimpleFilter('i', [$this, 'int']),
+			new \Twig_SimpleFilter('b', [$this, 'bool']),
 		];
+	}
+
+	/**
+	 * Cast value as a string.
+	 *
+	 * @param mixed $subject Value to be cast.
+	 * @return string
+	 */
+	public function string($subject)
+	{
+		return (string) $subject;
+	}
+
+	/**
+	 * Cast value as a float.
+	 *
+	 * @param mixed $subject Value to be cast.
+	 * @return float
+	 */
+	public function float($subject)
+	{
+		return (float) $subject;
+	}
+
+	/**
+	 * Cast value as a integer.
+	 *
+	 * @param mixed $subject Value to be cast.
+	 * @return int
+	 */
+	public function int($subject)
+	{
+		return (int) $subject;
+	}
+
+	/**
+	 * Cast value as a boolean.
+	 *
+	 * @param mixed $subject Value to be cast.
+	 * @return bool
+	 */
+	public function bool($subject)
+	{
+		return (bool) $subject;
 	}
 
 }


### PR DESCRIPTION
Addresses (most of) #7 

For each typecast filter, there is a one-letter alias as well (`string` and `s`). If you feel like this is overkill, feel free to pull it out.

I also didn't include `object` or `array` filters, because those are slightly more complex.