### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,6 @@ class Plugin extends \craft\base\Plugin
 
         // Custom initialization code goes here...
         // Add in our Twig extensions
-        \Craft::$app->view->twig->addExtension(new \marionnewlevant\twigperversion\twigextensions\TwigPerversionTwigExtension());
+        \Craft::$app->view->registerTwigExtension(new \marionnewlevant\twigperversion\twigextensions\TwigPerversionTwigExtension());
     }
 }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.