### PR TITLE
Fix `{% return %}` tags for Twig 3.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Making twig do things it really shouldn&#39;t. Twig is not intended to be a gene
 
 ## Requirements
 
-This plugin requires Craft CMS 3.1.29 or later.
+This plugin requires Craft CMS 4.12 or later.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "craftcms/cms": "^4.0"
+    "craftcms/cms": "^4.12"
   },
   "autoload": {
     "psr-4": {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,8 +1,41 @@
 <?php
 namespace marionnewlevant\twigperversion;
 
+use Twig\Markup;
+
 class Plugin extends \craft\base\Plugin
 {
+    /**
+     * @var array Values being returned by macros via `{% return %}` tags.
+     * @since 2.3.0
+     */
+    public static $returnValues = [];
+
+    /**
+     * Processes a macro response, searching for return markers left by `{% return %}` tags.
+     *
+     * If one is found, the value passed to the `{% return %}` tag will be returned instead.
+     *
+     * @param mixed $response
+     * @return mixed
+     * @since 2.3.0
+     */
+    public static function processMacroResponse(mixed $response): mixed
+    {
+        if ($response instanceof Markup) {
+            $markup = (string)$response;
+            $markerPos = strpos($markup, '[RETURN_MARKER:');
+            if ($markerPos !== false) {
+                $endPos = strpos($markup, ']', $markerPos);
+                $marker = substr($markup, $markerPos, $endPos - $markerPos + 1);
+                if (isset(self::$returnValues[$marker])) {
+                    return self::$returnValues[$marker];
+                }
+            }
+        }
+        return $response;
+    }
+
     public function init()
     {
         parent::init();

--- a/src/twigextensions/MacroProcessor_Node.php
+++ b/src/twigextensions/MacroProcessor_Node.php
@@ -1,0 +1,36 @@
+<?php
+namespace marionnewlevant\twigperversion\twigextensions;
+
+use marionnewlevant\twigperversion\Plugin;
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+
+/**
+ * Twig Perversion
+ *
+ * @package   TwigPerversion
+ * @author    Marion Newlevant
+ * @copyright Copyright (c) 2024, Marion Newlevant
+ * @license   MIT
+ * @link      https://github.com/marionnewlevant/craft-twig_perversion
+ * @since     2.3.0
+ */
+
+class MacroProcessor_Node extends AbstractExpression
+{
+    public function compile(Compiler $compiler): void
+    {
+        $compiler
+            ->raw("\n")
+            ->indent()
+            ->write(sprintf("%s::processMacroResponse(\n", Plugin::class))
+            ->indent()
+            ->write('')
+            ->subcompile($this->getNode('methodCallExpression'))
+            ->raw("\n")
+            ->outdent()
+            ->write(")\n")
+            ->outdent()
+            ->write('');
+    }
+}

--- a/src/twigextensions/Return_Node.php
+++ b/src/twigextensions/Return_Node.php
@@ -1,6 +1,8 @@
 <?php
 namespace marionnewlevant\twigperversion\twigextensions;
 
+use marionnewlevant\twigperversion\Plugin;
+
 /**
  * Twig Perversion
  *
@@ -19,9 +21,11 @@ class Return_Node extends \Twig\Node\Node
 	*/
 	public function compile(\Twig\Compiler $compiler)
 	{
+        $marker = sprintf('[RETURN_MARKER:%s]', mt_rand());
 		$compiler
-			->addDebugInfo($this)
-			->write('return ');
+            ->addDebugInfo($this)
+            ->write(sprintf("%s::\$returnValues['%s'] = ", Plugin::class, $marker));
+
 		// check for an expression to return.
 		if ($this->hasNode('expr')) {
 			$compiler->subcompile($this->getNode('expr'));
@@ -31,6 +35,8 @@ class Return_Node extends \Twig\Node\Node
 			$compiler->raw('""');
 		}
 
-		$compiler->raw(";\n");
+		$compiler
+            ->raw(";\n")
+            ->write(sprintf("yield '%s';\n", $marker));
 	}
 }

--- a/src/twigextensions/Return_Node.php
+++ b/src/twigextensions/Return_Node.php
@@ -21,10 +21,13 @@ class Return_Node extends \Twig\Node\Node
 	*/
 	public function compile(\Twig\Compiler $compiler)
 	{
-        $marker = sprintf('[RETURN_MARKER:%s]', mt_rand());
 		$compiler
             ->addDebugInfo($this)
-            ->write(sprintf("%s::\$returnValues['%s'] = ", Plugin::class, $marker));
+            ->write("if (!isset(\$returnedMarker)) {\n")
+            ->indent()
+            ->write("\$returnedMarker = true;\n")
+            ->write("\$marker = sprintf('[RETURN_MARKER:%s]', mt_rand());\n")
+            ->write(sprintf("%s::\$returnValues[\$marker] = ", Plugin::class));
 
 		// check for an expression to return.
 		if ($this->hasNode('expr')) {
@@ -37,6 +40,8 @@ class Return_Node extends \Twig\Node\Node
 
 		$compiler
             ->raw(";\n")
-            ->write(sprintf("yield '%s';\n", $marker));
+            ->write("yield \$marker;\n")
+            ->outdent()
+            ->write("}\n");
 	}
 }

--- a/src/twigextensions/Return_NodeVisitor.php
+++ b/src/twigextensions/Return_NodeVisitor.php
@@ -1,0 +1,42 @@
+<?php
+namespace marionnewlevant\twigperversion\twigextensions;
+
+use Twig\Environment;
+use Twig\Node\Expression\MethodCallExpression;
+use Twig\Node\Node;
+use Twig\NodeVisitor\NodeVisitorInterface;
+
+/**
+ * Twig Perversion
+ *
+ * @package   TwigPerversion
+ * @author    Marion Newlevant
+ * @copyright Copyright (c) 2024, Marion Newlevant
+ * @license   MIT
+ * @link      https://github.com/marionnewlevant/craft-twig_perversion
+ * @since     2.3.0
+ */
+class Return_NodeVisitor implements NodeVisitorInterface
+{
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        return $node;
+    }
+
+    public function leaveNode(Node $node, Environment $env): ?Node
+    {
+        if ($node instanceof MethodCallExpression && !$node->getAttribute('is_defined_test')) {
+            return new MacroProcessor_Node([
+                'methodCallExpression' => $node,
+            ], [
+                'is_generator' => $node->hasAttribute('is_generator') ? $node->getAttribute('is_generator') : false,
+            ]);
+        }
+        return $node;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
+}

--- a/src/twigextensions/TwigPerversionTwigExtension.php
+++ b/src/twigextensions/TwigPerversionTwigExtension.php
@@ -97,7 +97,14 @@ class TwigPerversionTwigExtension extends \Twig\Extension\AbstractExtension
 		];
 	}
 
-	/**
+    public function getNodeVisitors()
+    {
+        return [
+            new Return_NodeVisitor(),
+        ];
+    }
+
+    /**
 	 * Cast value as a string.
 	 *
 	 * @param mixed $subject Value to be cast.


### PR DESCRIPTION
Fixes `{% return %}` tags for Twig 3.12+ (#26) by storing the “returned” value in a static array on the `Plugin` class, and yields a marker token instead. A new node visitor looks for any method calls (e.g. to macros) and runs their responses through a new `Plugin::processMacroResponse()` method, which checks if the response contains a marker token, and if so, returns the corresponding value instead.