### PR TITLE
Replace return markers even when the macro returned `null`

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -28,7 +28,7 @@ class Plugin extends \craft\base\Plugin
             if ($markerPos !== false) {
                 $endPos = strpos($markup, ']', $markerPos);
                 $marker = substr($markup, $markerPos, $endPos - $markerPos + 1);
-                if (isset(self::$returnValues[$marker])) {
+                if (array_key_exists($marker, self::$returnValues)) {
                     return self::$returnValues[$marker];
                 }
             }


### PR DESCRIPTION
Previously, if a macro returned `null`, the `[RETURN_MARKER:12345]` tag would be left in the rendered output, due to `isset(self::$returnValues[$marker])` evaluating to false with a null array value. This changes that to an `array_key_exists` instead, which accurately identifies macros with a null return.

cc @brandonkelly 