### PR TITLE
[v2] Twig 3.15 compatibility

### DIFF
--- a/src/twigextensions/MacroProcessor_Node.php
+++ b/src/twigextensions/MacroProcessor_Node.php
@@ -26,7 +26,7 @@ class MacroProcessor_Node extends AbstractExpression
             ->write(sprintf("%s::processMacroResponse(\n", Plugin::class))
             ->indent()
             ->write('')
-            ->subcompile($this->getNode('methodCallExpression'))
+            ->subcompile($this->getNode('macroCallExpression'))
             ->raw("\n")
             ->outdent()
             ->write(")\n")

--- a/src/twigextensions/Return_NodeVisitor.php
+++ b/src/twigextensions/Return_NodeVisitor.php
@@ -2,6 +2,7 @@
 namespace marionnewlevant\twigperversion\twigextensions;
 
 use Twig\Environment;
+use Twig\Node\Expression\MacroReferenceExpression;
 use Twig\Node\Expression\MethodCallExpression;
 use Twig\Node\Node;
 use Twig\NodeVisitor\NodeVisitorInterface;
@@ -25,14 +26,22 @@ class Return_NodeVisitor implements NodeVisitorInterface
 
     public function leaveNode(Node $node, Environment $env): ?Node
     {
-        if ($node instanceof MethodCallExpression && !$node->getAttribute('is_defined_test')) {
-            return new MacroProcessor_Node([
-                'methodCallExpression' => $node,
-            ], [
-                'is_generator' => $node->hasAttribute('is_generator') ? $node->getAttribute('is_generator') : false,
-            ]);
+        if (class_exists(MacroReferenceExpression::class)) {
+            if (!$node instanceof MacroReferenceExpression) {
+                return $node;
+            }
+        } elseif (!$node instanceof MethodCallExpression) {
+            return $node;
         }
-        return $node;
+        if ($node->getAttribute('is_defined_test')) {
+            return $node;
+        }
+
+        return new MacroProcessor_Node([
+            'macroCallExpression' => $node,
+        ], [
+            'is_generator' => $node->hasAttribute('is_generator') ? $node->getAttribute('is_generator') : false,
+        ]);
     }
 
     public function getPriority()


### PR DESCRIPTION
Twig 3.15 (used by Craft 4.14 and 5.6) [refactored how macros are compiled](https://github.com/twigphp/Twig/pull/4402) which broke my `{% return %}` hack. This fixes it, while still maintaining Twig 3.14 compatibility as well.